### PR TITLE
Change init parameter from imaginary to imag

### DIFF
--- a/exercises/practice/complex-numbers/complex_numbers.py
+++ b/exercises/practice/complex-numbers/complex_numbers.py
@@ -1,5 +1,5 @@
 class ComplexNumber:
-    def __init__(self, real, imaginary):
+    def __init__(self, real, imag):
         pass
 
     def __eq__(self, other):


### PR DESCRIPTION
To align better with Python naming conventions for imaginary parts of numbers